### PR TITLE
Fix add_constant_constraint

### DIFF
--- a/plonk/constraint.py
+++ b/plonk/constraint.py
@@ -31,9 +31,9 @@ def add_mul_constarint(Ql, Qr, Qm, Qo, Qc):
 
 def add_constant_constraint(Ql, Qr, Qm, Qo, Qc, const):
 
-    Ql.append(0)
+    Ql.append(1)
     Qr.append(0)
-    Qm.append(1)
+    Qm.append(0)
     Qo.append(0)
     Qc.append(-const)
 


### PR DESCRIPTION
Paper section 6. 

In the add_constant_constraint, the Q_left instead of Q_multiplication has coefficient 1.

Need to fix the witness and other implementation too.